### PR TITLE
Add SPI driver class with factory integration

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(blink)
+add_subdirectory(spi_test)

--- a/app/spi_test/BSP_L476/note.txt
+++ b/app/spi_test/BSP_L476/note.txt
@@ -1,0 +1,1 @@
+Add the BSP files (Wait for TJ instruction)

--- a/app/spi_test/main.cc
+++ b/app/spi_test/main.cc
@@ -1,0 +1,42 @@
+#include "stm32l4xx.h"
+#include "st_spi.h"
+#include "st_spi_defs.h"
+
+using namespace LBR::Stml4;
+
+int main() {
+    //1. Enable clock for SPI1 and GPIOA (assuming PA5=SCK, PA6=MISO, PA7=MOSI)
+    RCC->APB2ENR |= RCC_APB2ENR_SPI1EN; // Enable SPI1 clock
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN; // Enable GPIOA clock
+
+    //2. Define SPI Settings
+    StSpiSettings spiSettings{
+        SpiBaudRate::FPCLK_8, // Baud rate divider
+        SpiBusMode::MODE1,    // CPOL=0, CPHA=1
+        SpiDataSize::DATA8_BIT,  // 8-bit data size
+        SpiBitOrder::MSB_FIRST, // MSB first
+        SpiRxThreshold::RX_8BIT // RX threshold
+    };
+
+    //3. Create SPI object for SPI1
+    HwSpi spi(SPI1, settings);
+
+    //4. Initialize SPI
+    if(spi.Init() != SpiStatus::OK) {
+        // Handle initialization error
+        while(1);
+    }
+
+    //5. Prepare data to send
+    uint8_t txData[] = {0xAA, 0x55};
+    spi.Send(txData, 2, 1000); // Send data with 1 second timeout 
+
+    //6. Test: Read 2 bytes (requires loopback: PA7 back to back with PA6)
+    uint8_t rxData[2] = {0};
+    spi.Read(rxData, 2, 1000); // Read data with 1 second timeout
+
+    //7. Debug: verify rx_data == tx_data if loopback is connected
+    while(1) {
+    __NOP(); //Idle loop
+    }
+}

--- a/app/spi_test/main.cc
+++ b/app/spi_test/main.cc
@@ -1,42 +1,51 @@
+/**
+ * @file main.cc
+ * @author Bex
+ * @brief SPI test application for STM32L4 using HwSpi driver
+ * @version 0.1
+ * @date 2025-10-01
+ */
+
+
 #include "stm32l4xx.h"
 #include "st_spi.h"
-#include "st_spi_defs.h"
+#include "st_spi_settings.h"
 
 using namespace LBR::Stml4;
 
 int main() {
-    //1. Enable clock for SPI1 and GPIOA (assuming PA5=SCK, PA6=MISO, PA7=MOSI)
-    RCC->APB2ENR |= RCC_APB2ENR_SPI1EN; // Enable SPI1 clock
-    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN; // Enable GPIOA clock
+    // Enable clock for SPI1 and GPIOA (PA5=SCK, PA6=MISO, PA7=MOSI)
+    RCC->APB2ENR |= RCC_APB2ENR_SPI1EN;   // Enable SPI1 clk
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN;  // Enable GPIOA clk
 
-    //2. Define SPI Settings
+    // Define SPI Settings
     StSpiSettings spiSettings{
-        SpiBaudRate::FPCLK_8, // Baud rate divider
-        SpiBusMode::MODE1,    // CPOL=0, CPHA=1
-        SpiDataSize::DATA8_BIT,  // 8-bit data size
-        SpiBitOrder::MSB_FIRST, // MSB first
-        SpiRxThreshold::RX_8BIT // RX threshold
+        SpiBaudRate::FPCLK_8,   
+        SpiBusMode::MODE2,      // CPOL=0, CPHA=1 (loopback test?)
+        SpiDataSize::DATA_8BIT, 
+        SpiBitOrder::MSB_FIRST, 
+        SpiRxThreshold::RX_8BIT 
     };
 
-    //3. Create SPI object for SPI1
-    HwSpi spi(SPI1, settings);
+    // Create SPI object for SPI1
+    HwSpi spi(SPI1, spiSettings);
 
-    //4. Initialize SPI
-    if(spi.Init() != SpiStatus::OK) {
-        // Handle initialization error
-        while(1);
+    // Initialize SPI
+    if (spi.Init() != SpiStatus::OK) {
+        // Check initialization error
+        while (1);
     }
 
-    //5. Prepare data to send
+    // Prepare data to send
     uint8_t txData[] = {0xAA, 0x55};
-    spi.Send(txData, 2, 1000); // Send data with 1 second timeout 
+    spi.Send(txData, 2, 1000); // Send 2 bytes 
 
-    //6. Test: Read 2 bytes (requires loopback: PA7 back to back with PA6)
+    // Read back 2 bytes (requires hardware loopback PA7 <-> PA6)
     uint8_t rxData[2] = {0};
-    spi.Read(rxData, 2, 1000); // Read data with 1 second timeout
+    spi.Read(rxData, 2, 1000);
 
-    //7. Debug: verify rx_data == tx_data if loopback is connected
-    while(1) {
-    __NOP(); //Idle loop
+    // Verify rxData matches txData if loopback is connected
+    while (1) {
+        __NOP(); //Main loop
     }
 }

--- a/common/drivers/bus/spi.h
+++ b/common/drivers/bus/spi.h
@@ -1,0 +1,29 @@
+/**
+    * @file spi.h
+    * @author Bex Saw  
+    * @brief SPI API interface
+    * @version 0.1
+    * @date 2024-10-05
+    * 
+    * @copyright Copyright (c) 2025
+    * 
+    */
+
+/** 
+ * @brief The interface for SPI communication
+        Read() - slave to master
+        Write() - master to slave
+        Transfer() - do both simultaneously 
+*/
+
+#pragma once
+
+namespace LBR {
+    class Spi {
+        public:
+            virtual bool Read(); 
+            virtual bool Write();
+            virtual bool Transfer();
+            ~Spi() = default;
+    };
+}

--- a/common/drivers/platform/stm32l4/st_spi.cc
+++ b/common/drivers/platform/stm32l4/st_spi.cc
@@ -1,0 +1,104 @@
+/**
+ * @file st_spi.cc
+ * @author Bex
+ * @brief SPI driver class implementation for STM32L4
+ * @version 0.1
+ * @date 2025-10-01
+ */
+
+#include "st_spi.h"
+
+namespace LBR {
+namespace Stml4 {
+
+/**
+ * @brief Initialize and configure the SPI peripheral
+ * - Sets master mode
+ * - Enables full-duplex
+ * - Applies baud rate, mode, data size, bit order, RX threshold
+ * - Enables software NSS
+ * - Turns SPI on
+ */
+
+SpiStatus HwSpi::Init() {
+    if (!instance_) return SpiStatus::INIT_ERR;
+
+    // Master mode
+    instance_->CR1 |= SPI_CR1_MSTR;
+
+    // Full-duplex (clear RXONLY to allow TX/RX together)
+    instance_->CR1 &= ~SPI_CR1_RXONLY;
+
+    // TODO: Fix the CR1 and CR2 settings based on current config baud rate
+
+    // Software slave management (keeps NSS high unless toggled)
+    instance_->CR1 |= (SPI_CR1_SSM | SPI_CR1_SSI);
+
+    // Enable SPI peripheral
+    instance_->CR1 |= SPI_CR1_SPE;
+
+    initialized_ = true;
+    return SpiStatus::OK;
+}
+
+/**
+ * @brief Configure baud rate (clock speed divider)
+ * @param baudrate Divider factor (F_PCLK / 2, 4, 8, …)
+ */
+bool HwSpi::SetSpiBaudRate(SpiBaudRate baudrate) {
+    if (!instance_) return false;
+    instance_->CR1 &= ~SPI_CR1_BR;  // Clear old divider
+    instance_->CR1 |= (static_cast<uint32_t>(baudrate) << SPI_CR1_BR_Pos);
+    return true;
+}
+
+/**
+ * @brief Configure clock polarity (CPOL) and phase (CPHA)
+ * @param mode Bus mode (0..3) that maps directly to CPOL/CPHA bits
+ */
+bool HwSpi::SetSpiBusMode(SpiBusMode mode) {
+    if (!instance_) return false;
+    instance_->CR1 &= ~(SPI_CR1_CPOL | SPI_CR1_CPHA);   // Clear old mode
+    instance_->CR1 |= static_cast<uint32_t>(mode);      // Apply mode bits
+    return true;
+}
+
+/**
+ * @brief Configure frame size (8-bit or 16-bit)
+ * @param size Frame size enum mapped to DS bits
+ */
+bool HwSpi::SetDataSize(SpiDataSize size) {
+    if (!instance_) return false;
+    instance_->CR2 &= ~SPI_CR2_DS;                      // Clear DS
+    instance_->CR2 |= (static_cast<uint32_t>(size) << SPI_CR2_DS_Pos);
+    return true;
+}
+
+/**
+ * @brief Configure bit order (MSB-first or LSB-first)
+ * @param order Which bit to shift out first
+ */
+bool HwSpi::SetBitOrder(SpiBitOrder order) {
+    if (!instance_) return false;
+    if (order == SpiBitOrder::MSB_FIRST)
+        instance_->CR1 &= ~SPI_CR1_LSBFIRST;
+    else
+        instance_->CR1 |=  SPI_CR1_LSBFIRST;
+    return true;
+}
+
+/**
+ * @brief Configure RX FIFO threshold (8-bit or 16-bit trigger level)
+ * @param th Threshold enum
+ */
+bool HwSpi::SetRxThreshold(SpiRxThreshold th) {
+    if (!instance_) return false;
+    if (th == SpiRxThreshold::RX_8BIT)
+        instance_->CR2 |=  SPI_CR2_FRXTH;
+    else
+        instance_->CR2 &= ~SPI_CR2_FRXTH;
+    return true;
+}
+
+} // namespace Stml4
+} // namespace LBR

--- a/common/drivers/platform/stm32l4/st_spi.cc
+++ b/common/drivers/platform/stm32l4/st_spi.cc
@@ -9,96 +9,123 @@
 #include "st_spi.h"
 
 namespace LBR {
-namespace Stml4 {
+    namespace Stml4 {
 
-/**
- * @brief Initialize and configure the SPI peripheral
- * - Sets master mode
- * - Enables full-duplex
- * - Applies baud rate, mode, data size, bit order, RX threshold
- * - Enables software NSS
- * - Turns SPI on
- */
+        /**
+         * @brief Initialize and configure the SPI peripheral
+         * - Sets master mode
+         * - Enables full-duplex
+         * - Applies baud rate, mode, data size, bit order, RX threshold
+         * - Enables software NSS
+         * - Turns SPI on
+         */
 
-SpiStatus HwSpi::Init() {
-    if (!instance_) return SpiStatus::INIT_ERR;
+        SpiStatus HwSpi::Init() {
+            if(!instance_) 
+                return SpiStatus::INIT_ERR;
+            
+            // Disable SPI before configuration
+            instance_->CR1 &= ~SPI_CR1_SPE;
 
-    // Master mode
-    instance_->CR1 |= SPI_CR1_MSTR;
+            // Master and full-duplex
+            instance_->CR1 |= SPI_CR1_MSTR 
+            instance_->CR1 &= ~SPI_CR1_RXONLY;
 
-    // Full-duplex (clear RXONLY to allow TX/RX together)
-    instance_->CR1 &= ~SPI_CR1_RXONLY;
+            // Slave select management (comeback later)
+            instance_->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
 
-    // TODO: Fix the CR1 and CR2 settings based on current config baud rate
+            //Apply settings
+            if(!SetSpiBaudRate(settings_.baudRate)) 
+                return SpiStatus::INIT_ERR;
+            if(!SetSpiBusMode(settings_.busMode)) 
+                return SpiStatus::INIT_ERR;
+            if(!SetSpiDataSize(settings_.dataSize))
+                return SpiStatus::INIT_ERR;
+            if(!SetSpiBitOrder(settings_.bitOrder))
+                return SpiStatus::INIT_ERR;
+            if(!SetSpiRxThreshold(settings_.rxThreshold))
+                return SpiStatus::INIT_ERR;
 
-    // Software slave management (keeps NSS high unless toggled)
-    instance_->CR1 |= (SPI_CR1_SSM | SPI_CR1_SSI);
+            // Enable SPI
+            instance_->CR1 |= SPI_CR1_SPE;
 
-    // Enable SPI peripheral
-    instance_->CR1 |= SPI_CR1_SPE;
+            initiaized_ = true;
+            return SpiStatus::OK;
+            }
 
-    initialized_ = true;
-    return SpiStatus::OK;
-}
+        /**
+         * @brief Congigure the SPI baud rate
+         * @param baudRate Desired baud rate setting
+         */
 
-/**
- * @brief Configure baud rate (clock speed divider)
- * @param baudrate Divider factor (F_PCLK / 2, 4, 8, …)
- */
-bool HwSpi::SetSpiBaudRate(SpiBaudRate baudrate) {
-    if (!instance_) return false;
-    instance_->CR1 &= ~SPI_CR1_BR;  // Clear old divider
-    instance_->CR1 |= (static_cast<uint32_t>(baudrate) << SPI_CR1_BR_Pos);
-    return true;
-}
+        bool HwSpi::SetSpiBaudRate(SpiBaudRate baudRate) {
+            if(!instance_) 
+                return false;
 
-/**
- * @brief Configure clock polarity (CPOL) and phase (CPHA)
- * @param mode Bus mode (0..3) that maps directly to CPOL/CPHA bits
- */
-bool HwSpi::SetSpiBusMode(SpiBusMode mode) {
-    if (!instance_) return false;
-    instance_->CR1 &= ~(SPI_CR1_CPOL | SPI_CR1_CPHA);   // Clear old mode
-    instance_->CR1 |= static_cast<uint32_t>(mode);      // Apply mode bits
-    return true;
-}
+            // Clear divider bits
+            instance_->CR1 &= ~SPI_CR1_BR;
 
-/**
- * @brief Configure frame size (8-bit or 16-bit)
- * @param size Frame size enum mapped to DS bits
- */
-bool HwSpi::SetDataSize(SpiDataSize size) {
-    if (!instance_) return false;
-    instance_->CR2 &= ~SPI_CR2_DS;                      // Clear DS
-    instance_->CR2 |= (static_cast<uint32_t>(size) << SPI_CR2_DS_Pos);
-    return true;
-}
+            // Set new baud rate
+            instance_->CR1 |= static_cast<uint32_t>(baudRate) << SPI_CR1_BR_Pos;
+            return true;
+            }
 
-/**
- * @brief Configure bit order (MSB-first or LSB-first)
- * @param order Which bit to shift out first
- */
-bool HwSpi::SetBitOrder(SpiBitOrder order) {
-    if (!instance_) return false;
-    if (order == SpiBitOrder::MSB_FIRST)
-        instance_->CR1 &= ~SPI_CR1_LSBFIRST;
-    else
-        instance_->CR1 |=  SPI_CR1_LSBFIRST;
-    return true;
-}
+        /**
+         * @brief Configure CPOL and CPHA
+         */
 
-/**
- * @brief Configure RX FIFO threshold (8-bit or 16-bit trigger level)
- * @param th Threshold enum
- */
-bool HwSpi::SetRxThreshold(SpiRxThreshold th) {
-    if (!instance_) return false;
-    if (th == SpiRxThreshold::RX_8BIT)
-        instance_->CR2 |=  SPI_CR2_FRXTH;
-    else
-        instance_->CR2 &= ~SPI_CR2_FRXTH;
-    return true;
-}
+        bool HwSpi::SetSpiBusMode(SpiBusMode busMode) {
+            if(!instance_) 
+                return false;
 
-} // namespace Stml4
-} // namespace LBR
+            // Clear CPOL and CPHA bits
+            instance_->CR1 &= ~(SPI_CR1_CPOL | SPI_CR1_CPHA);
+
+            // Set new bus mode
+            instance_->CR1 |= (static_cast<uint32_t>(busMode) << SPI_CR1_CPOL_Pos);
+            instance_->CR1 |= (static_cast<uint32_t>(busMode) & 0x01) << SPI_CR1_CPHA_Pos;
+            return true;
+            }
+        /**
+        * @brief Configure data frame size
+        */
+
+        bool HwSpi::SetDataSize(SpiDataSize size) {
+            if (!instance_) 
+                return false;
+            instance_->CR2 &= ~SPI_CR2_DS; // clear
+
+            if (size == SpiDataSize::DATA_8BIT)
+                instance_->CR2 |= (0x7U << SPI_CR2_DS_Pos); // 8-bit frame
+            else
+                instance_->CR2 |= (0xFU << SPI_CR2_DS_Pos); // 16-bit frame
+                return true;
+            }
+
+        /**
+        * @brief Configure bit order
+        */
+
+        bool HwSpi::SetBitOrder(SpiBitOrder order) {
+            if (!instance_) 
+                return false;
+            if (order == SpiBitOrder::MSB_FIRST)
+                instance_->CR1 &= ~SPI_CR1_LSBFIRST;
+            else
+                instance_->CR1 |=  SPI_CR1_LSBFIRST;
+            return true;
+            }
+
+        /**
+        * @brief Configure RX FIFO threshold
+        */
+        bool HwSpi::SetRxThreshold(SpiRxThreshold th) {
+            if (!instance_) return false;
+            if (th == SpiRxThreshold::RX_8BIT)
+                instance_->CR2 |=  SPI_CR2_FRXTH;
+            else
+                instance_->CR2 &= ~SPI_CR2_FRXTH;
+            return true;
+            }
+        }
+    }

--- a/common/drivers/platform/stm32l4/st_spi.h
+++ b/common/drivers/platform/stm32l4/st_spi.h
@@ -1,0 +1,63 @@
+/**
+ * @file    st_spi.h
+ * @author  Bex
+ * @brief   STM32L4 SPI Driver (C++ only, implements Spi interface)
+ * @version 0.1
+ * @date    2025-10-01
+ *
+ * @note Usage:
+ *   LBR::Stml4::HwSpi spi_obj(SPI1, settings);
+ *   spi_obj.Init();
+ *   spi_obj.Send(tx_buf, len, 1000);
+ */
+
+#pragma once
+
+#include "stm32l4xx.h"
+#include "spi.h"
+#include "st_spi_defs.h"
+#include <cstdint>
+#include <cstddef>
+
+namespace LBR {
+    namespace Stml4 {
+        class HwSpi : public Spi {
+        public: 
+            HwSpi() = default;
+
+            // Construct with peripheral + initial settings
+            HwSpi(SPI_TypeDef* instance, const SpiCrSettings& settings)
+                : instance_(instance), settings_(settings) {}
+
+            // Configure registers and enable SPI
+            SpiStatus Init();
+
+            // Blocking buffer operations
+            bool Send(const std::uint8_t* data, std::size_t size, std::uint32_t timeout);
+            bool Read(std::uint8_t* data, std::size_t size, std::uint32_t timeout);
+            bool Transfer(const std::uint8_t* tx_data, std::uint8_t* rx_data,
+                          std::size_t size, std::uint32_t timeout);
+
+            // Update settings (before Init or while disabled)
+            void ApplySettings(const SpiCrSettings& settings) { settings_ = settings; }
+
+            // Interface overrides (can just call the buffer ops)
+            bool Read() override;
+            bool Write() override;
+            bool Transfer() override;
+
+        private:
+            SPI_TypeDef* instance_{nullptr}; // SPI1, SPI2, SPI3...
+            SpiCrSettings settings_{};       // Current configuration
+            bool initialized_{false};        // State flag
+
+            // Internal helpers
+            bool SetSpiBaudRate(SpiBaudRate baudrate);
+            bool SetSpiBusMode(SpiBusMode mode);
+            bool SetDataSize(SpiDataSize size);
+            bool SetBitOrder(SpiBitOrder order);
+            bool SetRxThreshold(SpiRxThreshold th);
+            bool SpiConfigSettings(const SpiCrSettings& cfg);
+        };
+    } 
+}

--- a/common/drivers/platform/stm32l4/st_spi.h
+++ b/common/drivers/platform/stm32l4/st_spi.h
@@ -15,49 +15,62 @@
 
 #include "stm32l4xx.h"
 #include "spi.h"
-#include "st_spi_defs.h"
+#include "st_spi_settings.h"
 #include <cstdint>
 #include <cstddef>
 
 namespace LBR {
-    namespace Stml4 {
-        class HwSpi : public Spi {
-        public: 
-            HwSpi() = default;
+namespace Stml4 {
 
-            // Construct with peripheral + initial settings
-            HwSpi(SPI_TypeDef* instance, const SpiCrSettings& settings)
-                : instance_(instance), settings_(settings) {}
+class HwSpi : public Spi {
+public:
+    // Default constructor
+    HwSpi() = default;
 
-            // Configure registers and enable SPI
-            SpiStatus Init();
+    // Construct with peripheral + initial settings
+    HwSpi(SPI_TypeDef* instance, const StSpiSettings& settings)
+        : instance_(instance), settings_(settings) {}
 
-            // Blocking buffer operations
-            bool Send(const std::uint8_t* data, std::size_t size, std::uint32_t timeout);
-            bool Read(std::uint8_t* data, std::size_t size, std::uint32_t timeout);
-            bool Transfer(const std::uint8_t* tx_data, std::uint8_t* rx_data,
-                          std::size_t size, std::uint32_t timeout);
+    // Configure registers and enable SPI
+    SpiStatus Init();
 
-            // Update settings (before Init or while disabled)
-            void ApplySettings(const SpiCrSettings& settings) { settings_ = settings; }
+    // Basic blocking operations with timeout (ms)
+    bool Send(const std::uint8_t* data,
+              std::size_t size,
+              std::uint32_t timeout);
 
-            // Interface overrides (can just call the buffer ops)
-            bool Read() override;
-            bool Write() override;
-            bool Transfer() override;
+    bool Read(std::uint8_t* data,
+              std::size_t size,
+              std::uint32_t timeout);
 
-        private:
-            SPI_TypeDef* instance_{nullptr}; // SPI1, SPI2, SPI3...
-            SpiCrSettings settings_{};       // Current configuration
-            bool initialized_{false};        // State flag
+    bool Transfer(const std::uint8_t* tx_data,
+                  std::uint8_t* rx_data,
+                  std::size_t size,
+                  std::uint32_t timeout);
 
-            // Internal helpers
-            bool SetSpiBaudRate(SpiBaudRate baudrate);
-            bool SetSpiBusMode(SpiBusMode mode);
-            bool SetDataSize(SpiDataSize size);
-            bool SetBitOrder(SpiBitOrder order);
-            bool SetRxThreshold(SpiRxThreshold th);
-            bool SpiConfigSettings(const SpiCrSettings& cfg);
-        };
-    } 
-}
+    // Update settings (before Init or while disabled)
+    void ApplySettings(const StSpiSettings& settings) { settings_ = settings; }
+
+    // Interface overrides (can wrap buffer ops)
+    bool Read() override;
+    bool Write() override;
+    bool Transfer() override;
+
+private:
+    // Member variables
+    SPI_TypeDef*   instance_{nullptr};  // SPI1, SPI2, SPI3...
+    StSpiSettings  settings_{};         // Current configuration
+    bool           initialized_{false}; // State flag
+
+    // Internal helpers
+    bool SetSpiBaudRate(SpiBaudRate baudrate);
+    bool SetSpiBusMode(SpiBusMode mode);
+    bool SetDataSize(SpiDataSize size);
+    bool SetBitOrder(SpiBitOrder order);
+    bool SetRxThreshold(SpiRxThreshold th);
+
+    bool SpiConfigSettings(const StSpiSettings& cfg);
+};
+
+} 
+} 

--- a/common/drivers/platform/stm32l4/st_spi_defs.h
+++ b/common/drivers/platform/stm32l4/st_spi_defs.h
@@ -1,0 +1,98 @@
+/**
+ * @file st_spi_defs.h
+ * @author Bex Saw
+ * @brief SPI definitions that are specific to the STM32L4 series
+ * @version 0.1
+ * @date 2025-10-01
+ * 
+ */
+
+ #pragma once
+
+ #include "stm32l4xx.h"
+ #include <cstdint>
+
+ /**
+  * @brief These settings control how fast the SPI clock runs. The speed is set by dividing the main clock (FPCLK) by a number (n).
+  * 
+  */
+// Baud Rate Control
+enum class SpiBaudRate : std::uint8_t 
+{
+    FPCLK_2 = 0, 
+    FPCLK_4,       
+    FPCLK_8,       
+    FPCLK_16,      
+    FPCLK_32,      
+    FPCLK_64,      
+    FPCLK_128,     
+    FPCLK_256      
+};
+
+// CPOL & CPHA
+/**
+ * @brief SPI bus mode settings for Clock Polarity (CPOL) and Clock Phase (CPHA).
+ */
+
+enum class SpiBusMode : std::uint8_t {
+
+    MODE1 = 0, // CPOL=0, CPHA=0
+    MODE2,     // CPOL=0, CPHA=1
+    MODE3,     // CPOL=1, CPHA=0
+    MODE4      // CPOL=1, CPHA=1
+};
+
+/** 
+ * @brief Recieve MSB/LSB first through data transfer
+ * Purpose: This setting determines the order in which bits are transmitted and received over the SPI bus.
+ */
+
+ enum class SpiBitOrder : std::uint8_t {
+    MSB_FIRST = 0,
+    LSB_FIRST
+};
+
+
+/**
+ * @brief If the number of bits in the RX buffer reaches this threshold, it means new data is ready to be read.
+ * FIFO (RX Buffer): can hold multiple bytes, so this threshold helps manage when to read data.
+ */
+
+ enum class SpiRxThreshold : std::uint8_t {
+    RX_8BIT = 0,   // 8-bit threshold
+    RX_16BIT       // 16-bit threshold
+};
+
+/**
+ * @brief SPI device error checking and handling
+ * Purpose: These settings help manage and respond to errors that may occur during SPI communication.
+ */
+enum class SpiStatus : std::uint8_t {
+    OK = 0,           // No error
+    OVERRUN_ERR,      // Data overrun error
+    MODE_FAULT_ERR,   // Mode fault error
+    CRC_ERR,          // CRC error
+    UNEXPECTED_ERR    // Any other unexpected error
+};
+
+/**
+ * @brief SPI data frame size configuration
+ * Purpose: This setting determines how many bits are in each data frame transmitted or received over the SPI bus.
+ */
+enum class SpiDataSize : std::uint8_t {
+        DATA_8BIT = 0,   // 8-bit data frame
+        DATA_16BIT       // 16-bit data frame
+};  
+
+/**
+ * @brief SPI control register settings and configurations.
+ * Purpose: These settings configure how the SPI peripheral operates.
+ */
+ struct StSpiSettings {
+    SpiBaudRate baudRate;      // Baud rate control
+    SpiBusMode busMode;       // Bus mode (CPOL/CPHA)
+    SpiDataSize dataSize;     // Data frame size (8-bit or 16-bit)
+    SpiBitOrder bitOrder;     // Bit order (MSB/LSB first)
+    SpiRxThreshold rxThreshold; // RX buffer threshold
+ };
+

--- a/common/drivers/platform/stm32l4/st_spi_factory.cc
+++ b/common/drivers/platform/stm32l4/st_spi_factory.cc
@@ -1,58 +1,65 @@
 /**
- * @file st_spi_factory.cc
- * @author Bex
- * @brief Factory for creating valid SPI objects with GPIO settings
- * @version 0.1
- * @date 2025-10-05
+ * @file    st_spi_factory.cc
+ * @author  Bex
+ * @brief   Factory for creating valid SPI objects with GPIO settings
+ * @version 0.2
+ * @date    2025-10-05
  */
 
- #include "st_spi_factory.h"
+#include "st_spi_factory.h"
 
- namespace LBR {
-    namespace Stml4 {
-        /**
-         * @brief Create an SPI object with given instance, GPIO config, and SPI Settings
-         * - Configures SCK, MOSO, MISO pins with alternate function
-         * - Applies user-provided SPI settings
-         */
-        HwSpi CreateSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings) {
-            
-            // Construct SPI object with instance + settings
-            HwSpi spi(spi_instance, spi_settings);
+namespace LBR {
+namespace Stml4 {
 
-            // Initialize GPIO pins for SPI
-            HwGpio sck_pin(gpio_config.sck_settings.port, gpio_config.sck_settings.pin_num);
-            sck_pin.Init(CreateSpiPinSettings(spi_settings.af));
-            HwGpio miso_pin(gpio_config.miso_settings.port, gpio_config.miso_settings.pin_num);
-            miso_pin.Init(CreateSpiPinSettings(spi_settings.af));
-            HwGpio mosi_pin(gpio_config.mosi_settings.port, gpio_config.mosi_settings.pin_num);
-            mosi_pin.Init(CreateSpiPinSettings(spi_settings.af));
+/**
+ * @brief Create an SPI object with given instance, GPIO config, and SPI settings
+ * - Configures SCK, MOSI, and MISO pins with alternate function
+ * - Applies user-provided SPI settings
+ */
+HwSpi CreateSpi(SPI_TypeDef* spi_instance,
+                const SpiGpioConfig& gpio_config,
+                const StSpiSettings& spi_settings) {
+    // Construct SPI object with instance + settings
+    HwSpi spi(spi_instance, spi_settings);
 
-            return spi;
-        }
+    // Initialize GPIO pins for SPI
+    HwGpio sck_pin(gpio_config.sck_settings.port, gpio_config.sck_settings.pin_num);
+    sck_pin.Init(CreateSpiPinSettings(gpio_config.sck_settings.af));
 
-    /** 
-     * @brief Validate the SPI object
-     * @return true if initialized successfully, false otherwise
-     */
-    bool ValidateSpi(HwSpi& spi) {
-        return(spi.Init() == SpiStatus::OK);
+    HwGpio miso_pin(gpio_config.miso_settings.port, gpio_config.miso_settings.pin_num);
+    miso_pin.Init(CreateSpiPinSettings(gpio_config.miso_settings.af));
+
+    HwGpio mosi_pin(gpio_config.mosi_settings.port, gpio_config.mosi_settings.pin_num);
+    mosi_pin.Init(CreateSpiPinSettings(gpio_config.mosi_settings.af));
+
+    return spi;
+}
+
+/**
+ * @brief Validate the SPI object
+ * @return true if initialized successfully, false otherwise
+ */
+bool ValidateSpi(HwSpi& spi) {
+    return (spi.Init() == SpiStatus::OK);
+}
+
+/**
+ * @brief High-level factory function to get a validated SPI object
+ * - Creates SPI object with GPIO config and settings
+ * - Validates initialization
+ * - Returns SPI object if valid, otherwise a default invalid SPI object
+ */
+HwSpi GetSpi(SPI_TypeDef* spi_instance,
+             const SpiGpioConfig& gpio_config,
+             const StSpiSettings& spi_settings) {
+    HwSpi spi = CreateSpi(spi_instance, gpio_config, spi_settings);
+    if (ValidateSpi(spi)) {
+        return spi; // return the valid object
+    } else {
+        // Return a default invalid SPI object
+        return HwSpi(nullptr, StSpiSettings{});
     }
+}
 
-    /**
-     * @brief High-level factory function to get a validated SPI object
-     * - Creates SPI object with GPIO config and settings
-     * - Validates initialization
-     * - Returns SPI object if valid, otherwise a default invalid SPI object
-     */
-    HwSpi GetSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings) {
-        HwSpi spi = CreateSpi(spi_instance, gpio_config, spi_settings);
-        if (ValidateSpi(spi)) {
-            return HwSpi();
-        } else {
-            // Return a default invalid SPI object
-            return HwSpi(nullptr, StSpiSettings{});
-        }
 }
-}
-}
+} 

--- a/common/drivers/platform/stm32l4/st_spi_factory.cc
+++ b/common/drivers/platform/stm32l4/st_spi_factory.cc
@@ -1,0 +1,58 @@
+/**
+ * @file st_spi_factory.cc
+ * @author Bex
+ * @brief Factory for creating valid SPI objects with GPIO settings
+ * @version 0.1
+ * @date 2025-10-05
+ */
+
+ #include "st_spi_factory.h"
+
+ namespace LBR {
+    namespace Stml4 {
+        /**
+         * @brief Create an SPI object with given instance, GPIO config, and SPI Settings
+         * - Configures SCK, MOSO, MISO pins with alternate function
+         * - Applies user-provided SPI settings
+         */
+        HwSpi CreateSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings) {
+            
+            // Construct SPI object with instance + settings
+            HwSpi spi(spi_instance, spi_settings);
+
+            // Initialize GPIO pins for SPI
+            HwGpio sck_pin(gpio_config.sck_settings.port, gpio_config.sck_settings.pin_num);
+            sck_pin.Init(CreateSpiPinSettings(spi_settings.af));
+            HwGpio miso_pin(gpio_config.miso_settings.port, gpio_config.miso_settings.pin_num);
+            miso_pin.Init(CreateSpiPinSettings(spi_settings.af));
+            HwGpio mosi_pin(gpio_config.mosi_settings.port, gpio_config.mosi_settings.pin_num);
+            mosi_pin.Init(CreateSpiPinSettings(spi_settings.af));
+
+            return spi;
+        }
+
+    /** 
+     * @brief Validate the SPI object
+     * @return true if initialized successfully, false otherwise
+     */
+    bool ValidateSpi(HwSpi& spi) {
+        return(spi.Init() == SpiStatus::OK);
+    }
+
+    /**
+     * @brief High-level factory function to get a validated SPI object
+     * - Creates SPI object with GPIO config and settings
+     * - Validates initialization
+     * - Returns SPI object if valid, otherwise a default invalid SPI object
+     */
+    HwSpi GetSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings) {
+        HwSpi spi = CreateSpi(spi_instance, gpio_config, spi_settings);
+        if (ValidateSpi(spi)) {
+            return HwSpi();
+        } else {
+            // Return a default invalid SPI object
+            return HwSpi(nullptr, StSpiSettings{});
+        }
+}
+}
+}

--- a/common/drivers/platform/stm32l4/st_spi_factory.h
+++ b/common/drivers/platform/stm32l4/st_spi_factory.h
@@ -1,0 +1,75 @@
+/**
+ * @file    st_spi_factory.h
+ * @author  Bex Saw
+ * @brief Factory for creating valid SPI objects with GPIO settings
+ * @version 0.1
+ * @date 2025-10-05
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+#pragma once
+
+#include "st_spi.h"
+#include "st_gpio.h"
+
+/**
+ * @note:
+ * Factory pattern:
+ * 1. Configures SPI GPIO pins (SCK, MISO, MOSI)
+ * 2. Creates and validates a HwSPI object
+ * 3. Provides a simple GetSpi() interface for BSP
+ */
+
+ namespace LBR {
+    namespace Stml4 {
+
+        /**
+         * @brief Build a default GPIO settings struct for SPI pins
+         * @param sck_pin GPIO pin for SCK
+        
+        */
+       inline StGpioSettings CreateSpiPinSettings(uint8_t af) {
+           return StGpioSettings{
+               .mode = StGpioMode::ALTERNATE,
+               .otype = StGpioOType::PUSHPULL,
+               .pupd = StGpioPuPd::NOPUPD,
+               .speed = StGpioSpeed::VERY_HIGH,
+               .af = af
+           };
+       }
+
+    struct GpioName {
+        GPIO_TypeDef* port;
+        std::uint8_t pin_num;
+    };
+
+    /**
+     * @brief COllection of GPIO configs for SCK, MISO, MOSI pins.
+     */
+
+    struct SpiGpioConfig {
+        GpioName sck_settings;
+        GpioName miso_settings;
+        GpioName mosi_settings;
+    };
+
+    /**
+     * @brief Names (port and pin number) for SPI GPIO pins
+     */
+    struct SpiGpioNames {
+        GpioName sck_name;
+        GpioName miso_name;
+        GpioName mosi_name;
+    };
+
+    HwSpi CreateSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings);
+
+
+    //CHeck if a given SPI object is valid and initialized
+    bool ValidateSpi(HwSpi& spi);
+
+    HwSpi GetSpi(SPI_TypeDef* spi_instance, const SpiGpioConfig& gpio_config, const StSpiSettings& spi_settings);
+    } 
+ }
+ 

--- a/common/drivers/platform/stm32l4/st_spi_settings.h
+++ b/common/drivers/platform/stm32l4/st_spi_settings.h
@@ -1,5 +1,5 @@
 /**
- * @file st_spi_defs.h
+ * @file st_spi_settings.h
  * @author Bex Saw
  * @brief SPI definitions that are specific to the STM32L4 series
  * @version 0.1
@@ -69,10 +69,10 @@ enum class SpiBusMode : std::uint8_t {
  */
 enum class SpiStatus : std::uint8_t {
     OK = 0,           // No error
-    OVERRUN_ERR,      // Data overrun error
-    MODE_FAULT_ERR,   // Mode fault error
-    CRC_ERR,          // CRC error
-    UNEXPECTED_ERR    // Any other unexpected error
+    READ_ERR,
+    WRITE_ERR,
+    TRANSFER_ERR,
+    INIT_ERR
 };
 
 /**


### PR DESCRIPTION
- Adds an SPI driver class (`HwSpi`) with factory integration. 
- Includes helper functions for configuring baud rate, bus mode, data size, bit order, and RX threshold. 
- SPI read, write, and transfer. 