### PR TITLE
bs-imu-n-i2c-hotfix

### DIFF
--- a/app/bmp390_test/bsp_l476/l476_board.cc
+++ b/app/bmp390_test/bsp_l476/l476_board.cc
@@ -6,19 +6,19 @@
 
 namespace LBR
 {
-// SCL pin config (PB8)
+// SCL pin config (PB6)
 Stml4::StGpioSettings scl_settings{
     Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
     Stml4::GpioOspeed::LOW, Stml4::GpioPupd::PULL_UP, 4};
 
-const Stml4::StGpioParams scl_params{scl_settings, 8, GPIOB};
+const Stml4::StGpioParams scl_params{scl_settings, 6, GPIOB};
 
-// SDA pin config (PB9)
+// SDA pin config (PB7)
 Stml4::StGpioSettings sda_settings{
     Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
     Stml4::GpioOspeed::LOW, Stml4::GpioPupd::PULL_UP, 4};
 
-const Stml4::StGpioParams sda_params{sda_settings, 9, GPIOB};
+const Stml4::StGpioParams sda_params{sda_settings, 7, GPIOB};
 
 // I2C config
 const Stml4::StI2cParams i2c_params{I2C1, 0x10909CEC};

--- a/app/i2c_test/bsp_l476/l476_board.cc
+++ b/app/i2c_test/bsp_l476/l476_board.cc
@@ -5,19 +5,19 @@
 
 namespace LBR
 {
-// SCL pin config (PB8)
+// SCL pin config (PB6)
 Stml4::StGpioSettings scl_settings{
     Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
     Stml4::GpioOspeed::LOW, Stml4::GpioPupd::PULL_UP, 4};
 
-const Stml4::StGpioParams scl_params{scl_settings, 8, GPIOB};
+const Stml4::StGpioParams scl_params{scl_settings, 6, GPIOB};
 
-// SDA pin config (PB9)
+// SDA pin config (PB7)
 Stml4::StGpioSettings sda_settings{
     Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
     Stml4::GpioOspeed::LOW, Stml4::GpioPupd::PULL_UP, 4};
 
-const Stml4::StGpioParams sda_params{sda_settings, 9, GPIOB};
+const Stml4::StGpioParams sda_params{sda_settings, 7, GPIOB};
 
 // I2C config
 const Stml4::StI2cParams i2c_params{I2C1, 0x10909CEC};

--- a/app/imu_test/bsp_l476/imu_app_bsp.cc
+++ b/app/imu_test/bsp_l476/imu_app_bsp.cc
@@ -12,7 +12,7 @@ bool bsp_init()
     RCC->AHB2ENR |= RCC_AHB2ENR_GPIOBEN;
     RCC->APB1ENR1 |= RCC_APB1ENR1_I2C1EN;
 
-    // Configure PB8 = I2C1_SCL, PB9 = I2C1_SDA (AF4, open-drain, pull-up)
+    // Configure PB6 = I2C1_SCL, PB7 = I2C1_SDA (AF4, open-drain, pull-up)
     Stml4::StGpioSettings gpio_settings{
         Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
         Stml4::GpioOspeed::HIGH, Stml4::GpioPupd::PULL_UP,
@@ -20,8 +20,8 @@ bool bsp_init()
     };
 
     // Initialize GPIO pins for I2C
-    Stml4::StGpioParams scl{gpio_settings, 8, GPIOB};
-    Stml4::StGpioParams sda{gpio_settings, 9, GPIOB};
+    Stml4::StGpioParams scl{gpio_settings, 6, GPIOB};
+    Stml4::StGpioParams sda{gpio_settings, 7, GPIOB};
     Stml4::HwGpio scl_gpio(scl);
     Stml4::HwGpio sda_gpio(sda);
     scl_gpio.init();
@@ -68,7 +68,7 @@ Board& get_board()
     RCC->AHB2ENR |= RCC_AHB2ENR_GPIOBEN;
     RCC->APB1ENR1 |= RCC_APB1ENR1_I2C1EN;
 
-    // Configure PB8 = I2C1_SCL, PB9 = I2C1_SDA (AF4, open-drain, pull-up)
+    // Configure PB6 = I2C1_SCL, PB7 = I2C1_SDA (AF4, open-drain, pull-up)
     Stml4::StGpioSettings gpio_settings{
         Stml4::GpioMode::ALT_FUNC, Stml4::GpioOtype::OPEN_DRAIN,
         Stml4::GpioOspeed::HIGH, Stml4::GpioPupd::PULL_UP,
@@ -76,8 +76,8 @@ Board& get_board()
     };
 
     // Initialize GPIO pins for I2C
-    Stml4::StGpioParams scl{gpio_settings, 8, GPIOB};
-    Stml4::StGpioParams sda{gpio_settings, 9, GPIOB};
+    Stml4::StGpioParams scl{gpio_settings, 6, GPIOB};
+    Stml4::StGpioParams sda{gpio_settings, 7, GPIOB};
     Stml4::HwGpio scl_gpio(scl);
     Stml4::HwGpio sda_gpio(sda);
     scl_gpio.init();


### PR DESCRIPTION
Fixing SCL & SDA pins relative to FlightModule

SCL PB8->PB6
SDA PB9->PB7

<img width="777" height="641" alt="image" src="https://github.com/user-attachments/assets/63af2bd6-3fbe-4174-b0a6-4c62687b9d92" />



