### PR TITLE
gd-servo

### DIFF
--- a/app/servo_test/main.cc
+++ b/app/servo_test/main.cc
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
     while (1)
     {
         angle += 30;
-        if (angle > 180)
+        if (angle > 270)
         {
             angle = 0;
         }


### PR DESCRIPTION
Added bsp_h723 support to servo_test app for the ANNIMOS 45KG 270° servo.

Changes:
- Added app/servo_test/bsp_h723/h723_board.cc — H723 BSP wiring for TIM4 CH3 (PB8)
- Added app/servo_test/bsp_h723/CMakeLists.txt
- Updated servo_test CMakeLists.txt to include H723 target
- Updated main.cc angle limit from 180° to 270° for ANNIMOS servo

Built and flashed successfully on NUCLEO-H723ZG. PWM signal confirmed on PB8.